### PR TITLE
Add Register Request Body Model for User Registration

### DIFF
--- a/lib/features/auth/data/models/register_req_body.dart
+++ b/lib/features/auth/data/models/register_req_body.dart
@@ -1,0 +1,20 @@
+class RegisterReqBody {
+  final String name;
+  final String email;
+  final String password;
+
+  RegisterReqBody({
+    required this.name,
+    required this.email,
+    required this.password,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'email': email,
+        'password': password,
+      };
+      
+
+  
+}


### PR DESCRIPTION
This PR introduces the `RegisterReqBody` model, which encapsulates the necessary data for user registration requests. The model includes:
- `name`: The user's name
- `email`: The user's email
- `password`: The user's password

The `toJson()` method converts the data into a JSON format required for making API requests. This model simplifies and standardizes the request body structure for registration endpoints.
