### PR TITLE
Implement OTP Email Sending Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# .gitignore
+.env

--- a/lib/core/helpers/send_mail_helper.dart
+++ b/lib/core/helpers/send_mail_helper.dart
@@ -1,0 +1,37 @@
+import 'package:mailer/mailer.dart';
+import 'package:mailer/smtp_server.dart';
+
+import 'logger_helper.dart'; // Assuming LoggerHelper is in a separate file.
+
+class SendMailHelper {
+  final String username;
+  final String password;
+  final SmtpServer smtpServer;
+
+  SendMailHelper({
+    required this.username,
+    required this.password,
+  }) : smtpServer = gmail(username, password);
+
+  // Method to send OTP email
+  Future<void> sendOtpEmail(String recipientEmail, String otpCode) async {
+    final message = Message()
+      ..from = Address(username, 'Selaty App')
+      ..recipients.add(recipientEmail)
+      ..subject = 'Your OTP Code for Selaty App'
+      ..text = 'Your OTP code is: $otpCode' // Plain text version
+      ..html =
+          "<h1>Your OTP Code</h1>\n<p>Your OTP code is: <strong>$otpCode</strong></p>"; // HTML version
+
+    try {
+      final sendReport = await send(message, smtpServer);
+      LoggerHelper.info(
+          'OTP email sent to $recipientEmail. Send report: $sendReport');
+    } on MailerException catch (e) {
+      LoggerHelper.error('Failed to send OTP email to $recipientEmail.', e);
+      for (var p in e.problems) {
+        LoggerHelper.error('Problem: ${p.code}: ${p.msg}');
+      }
+    }
+  }
+}

--- a/lib/features/auth/data/data_sources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/data_sources/auth_remote_data_source.dart
@@ -80,7 +80,8 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   }
 
   @override
-  Future<Either> sendOtp(
+
+  Future<Either<String, SendOtpResponseData>> sendOtp(
       {required SendOtpReqBody forgetPasswordReqBody}) async {
     try {
       var response = await sl<DioClient>().post(ApiConstants.forgotPasswordUrl,
@@ -88,7 +89,7 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       SendOtpResponse forgetPassResponse =
           SendOtpResponse.fromJson(response.data);
       if (forgetPassResponse.status) {
-        return Right(forgetPassResponse.data);
+        return Right(forgetPassResponse.data!);
       } else {
         return Left(forgetPassResponse.message);
       }

--- a/lib/features/auth/data/repository/auth_repo_impl.dart
+++ b/lib/features/auth/data/repository/auth_repo_impl.dart
@@ -6,6 +6,7 @@ import 'package:selaty/features/auth/data/models/login_req_body.dart';
 import 'package:selaty/features/auth/data/models/login_response.dart';
 import 'package:selaty/features/auth/data/models/register_req_body.dart';
 import 'package:selaty/features/auth/data/models/send_otp_req_body.dart';
+import 'package:selaty/features/auth/data/models/send_otp_response.dart';
 import 'package:selaty/features/auth/domain/repository/auth_repo.dart';
 
 class AuthRepoImpl implements AuthRepo {
@@ -56,13 +57,15 @@ class AuthRepoImpl implements AuthRepo {
   }
 
   @override
-  Future<Either> sendOtp(
+  Future<Either<String,SendOtpResponseData>> sendOtp(
       {required SendOtpReqBody forgetPasswordReqBody}) async {
     final result = await sl<AuthRemoteDataSource>()
         .sendOtp(forgetPasswordReqBody: forgetPasswordReqBody);
     return result.fold(
       (error) => Left(error),
       (success) async {
+        
+        
         return Right(success);
       },
     );

--- a/lib/features/auth/domain/repository/auth_repo.dart
+++ b/lib/features/auth/domain/repository/auth_repo.dart
@@ -3,6 +3,7 @@ import 'package:selaty/features/auth/data/models/login_req_body.dart';
 import 'package:selaty/features/auth/data/models/login_response.dart';
 import 'package:selaty/features/auth/data/models/register_req_body.dart';
 import 'package:selaty/features/auth/data/models/send_otp_req_body.dart';
+import 'package:selaty/features/auth/data/models/send_otp_response.dart';
 
 abstract class AuthRepo {
   Future<Either> register({required RegisterReqBody registerReqBody});
@@ -10,5 +11,6 @@ abstract class AuthRepo {
   Future<void> logout();
   Future<LoginUserData?> getCachedUser();
   Future<bool> isLoggedIn();
-  Future<Either> sendOtp({required SendOtpReqBody forgetPasswordReqBody});
+  Future<Either<String, SendOtpResponseData>> sendOtp(
+      {required SendOtpReqBody forgetPasswordReqBody});
 }

--- a/lib/features/auth/domain/usecases/send_otp_usecase.dart
+++ b/lib/features/auth/domain/usecases/send_otp_usecase.dart
@@ -2,11 +2,12 @@ import 'package:dartz/dartz.dart';
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/core/usecase/usecase.dart';
 import 'package:selaty/features/auth/data/models/send_otp_req_body.dart';
+import 'package:selaty/features/auth/data/models/send_otp_response.dart';
 import 'package:selaty/features/auth/domain/repository/auth_repo.dart';
 
-class SendOtpUsecase extends UseCase<Either, ForgetPassParms> {
+class SendOtpUsecase extends UseCase<Either, SendOtpParms> {
   @override
-  Future<Either<dynamic, dynamic>> call({ForgetPassParms? param}) async {
+  Future<Either<String, SendOtpResponseData>> call({SendOtpParms? param}) async {
     if (param == null) throw ArgumentError('RegisterParams cannot be null');
 
     return await sl<AuthRepo>()
@@ -14,8 +15,8 @@ class SendOtpUsecase extends UseCase<Either, ForgetPassParms> {
   }
 }
 
-class ForgetPassParms {
+class SendOtpParms {
   final SendOtpReqBody forgetPasswordReqBody;
 
-  ForgetPassParms({required this.forgetPasswordReqBody});
+  SendOtpParms({required this.forgetPasswordReqBody});
 }

--- a/lib/features/auth/presentation/logic/forget_password/send_otp_cubit.dart
+++ b/lib/features/auth/presentation/logic/forget_password/send_otp_cubit.dart
@@ -1,8 +1,11 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart'; // Import dotenv
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/core/enums/status.dart';
+import 'package:selaty/core/helpers/send_mail_helper.dart';
 import 'package:selaty/features/auth/data/models/send_otp_req_body.dart';
+import 'package:selaty/features/auth/data/models/send_otp_response.dart'; // Adjust the path as needed
 import 'package:selaty/features/auth/domain/usecases/send_otp_usecase.dart';
 import 'package:selaty/features/auth/presentation/logic/forget_password/send_otp_state.dart';
 
@@ -13,14 +16,28 @@ class SendOtpCubit extends Cubit<SendOtpState> {
     emit(state.copyWith(status: ForgetPasswordStatus.loading));
 
     final Either result = await sl<SendOtpUsecase>().call(
-        param: ForgetPassParms(forgetPasswordReqBody: forgetPasswordReqBody));
+        param: SendOtpParms(forgetPasswordReqBody: forgetPasswordReqBody));
 
     result.fold(
       (failure) => emit(
           state.copyWith(status: ForgetPasswordStatus.error, message: failure)),
-      (success) => emit(state.copyWith(
-          status: ForgetPasswordStatus.success, response: success)),
+      (success) async {
+        emit(state.copyWith(
+            status: ForgetPasswordStatus.success, response: success));
+
+        await sendOtpEmail(success);
+      },
     );
+  }
+
+  Future<void> sendOtpEmail(SendOtpResponseData response) async {
+    String username = 'hmdy7486@gmail.com';
+    String password = dotenv.env['APP_PASSWORD'] ?? '';
+
+    final sendMailHelper =
+        SendMailHelper(username: username, password: password);
+    await sendMailHelper.sendOtpEmail(
+        response.email, response.newPassword.toString());
   }
 
   void reset() {

--- a/lib/features/auth/presentation/views/otp_view.dart
+++ b/lib/features/auth/presentation/views/otp_view.dart
@@ -5,6 +5,7 @@ import 'package:selaty/core/common/widgets/primary_button.dart';
 import 'package:selaty/core/constants/colors.dart';
 import 'package:selaty/core/constants/styles.dart';
 import 'package:selaty/core/helpers/helper_functions.dart';
+import 'package:selaty/features/auth/presentation/views/new_password_view.dart';
 
 class OtpView extends StatefulWidget {
   const OtpView({super.key, required this.otp, required this.token});
@@ -27,7 +28,7 @@ class _OtpViewState extends State<OtpView> {
 
     // Responsive sizing
     final baseSize = size.width * (isPortrait ? 0.17 : 0.1);
-    final pinFieldSize = baseSize.clamp(50.0, 70.0);
+    final pinFieldSize = baseSize.clamp(40.0, 50.0);
     final horizontalPadding = size.width * (isPortrait ? 0.04 : 0.09);
     final verticalPadding = size.height * (isPortrait ? 0.04 : 0.07);
 
@@ -58,8 +59,9 @@ class _OtpViewState extends State<OtpView> {
                 Directionality(
                   textDirection: TextDirection.ltr,
                   child: PinCodeTextField(
+                    keyboardType: TextInputType.number,
                     appContext: context,
-                    length: 4,
+                    length: 6,
                     obscureText: false,
                     animationType: AnimationType.fade,
                     pinTheme: PinTheme(
@@ -119,11 +121,15 @@ class _OtpViewState extends State<OtpView> {
   }
 
   void _handleOtpSubmit(String otp) {
-    if (otp == '1234') {
-      // Navigator.pushReplacement(
-      //   context,
-      //MaterialPageRoute(   // builder: (context) => NewPasswordView(old_password: widget.email)),
-      //  );
+    if (otp == widget.otp.toString()) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+            builder: (context) => NewPasswordView(
+                  otp: widget.otp,
+                  token: widget.token,
+                )),
+      );
     } else {
       THelperFunctions.showSnackBar(
           context: context, message: 'الكود غير صحيح');

--- a/lib/features/auth/presentation/views/verify_email_view.dart
+++ b/lib/features/auth/presentation/views/verify_email_view.dart
@@ -11,7 +11,7 @@ import 'package:selaty/core/validators/validator.dart';
 import 'package:selaty/features/auth/data/models/send_otp_req_body.dart';
 import 'package:selaty/features/auth/presentation/logic/forget_password/send_otp_cubit.dart';
 import 'package:selaty/features/auth/presentation/logic/forget_password/send_otp_state.dart';
-import 'package:selaty/features/auth/presentation/views/new_password_view.dart';
+import 'package:selaty/features/auth/presentation/views/otp_view.dart';
 
 class VerifyEmailView extends StatefulWidget {
   const VerifyEmailView({super.key});
@@ -36,7 +36,7 @@ class _VerifyEmailViewState extends State<VerifyEmailView> {
     final isPortrait =
         Orientation.portrait == MediaQuery.of(context).orientation;
     return BlocListener<SendOtpCubit, SendOtpState>(
-      listener: (context, state) {
+      listener: (context, state) async {
         if (state.status == ForgetPasswordStatus.success) {
           THelperFunctions.showSnackBar(
               context: context, message: "تم إرسال رمز التحقق");
@@ -44,7 +44,7 @@ class _VerifyEmailViewState extends State<VerifyEmailView> {
           Navigator.pushReplacement(
             context,
             MaterialPageRoute(
-                builder: (context) => NewPasswordView(
+                builder: (context) => OtpView(
                       token: state.response!.token,
                       otp: state.response!.newPassword,
                     )),

--- a/lib/main_development.dart
+++ b/lib/main_development.dart
@@ -1,5 +1,6 @@
 import 'package:device_preview/device_preview.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/selaty.dart';
@@ -8,6 +9,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await ScreenUtil.ensureScreenSize();
   await setupServiceLocator();
+  await dotenv.load(fileName: ".env");
   runApp(DevicePreview(
       enabled: true,
       builder: (context) {

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/selaty.dart';
@@ -7,5 +8,6 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await ScreenUtil.ensureScreenSize();
   await setupServiceLocator();
+  await dotenv.load(fileName: ".env");
   runApp(const Selaty());
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -246,6 +246,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
   flutter_launcher_icons:
     dependency: "direct main"
     description:
@@ -485,6 +493,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  mailer:
+    dependency: "direct main"
+    description:
+      name: mailer
+      sha256: "21fde1497c79f402cb5fa7c50abd58927d360139e492546c941ee10767684fac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.0"
   matcher:
     dependency: transitive
     description:
@@ -509,6 +533,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
   permission_handler: 
   shared_preferences: 
   cached_network_image: 
+  mailer: 
+  flutter_dotenv: 
 
 dev_dependencies:
   flutter_lints:
@@ -47,6 +49,7 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
     - assets/images/
+    - .env
 
   fonts:
     - family: Cairo


### PR DESCRIPTION
### Description
This PR introduces the `SendMailHelper` class that leverages the `mailer` package to send OTP emails to users. It includes the following changes:

- Added the `SendMailHelper` class for handling OTP email functionality.
- Integrated the `dotenv` package to manage sensitive information, including the `APP_PASSWORD`.
- Updated the `sendOtp` method in the `AuthRepoImpl` class to utilize the `SendMailHelper` for sending OTP emails after a successful request.
- Configured the application to load environment variables from a `.env` file.

### How to Test
1. Ensure the `.env` file is correctly set up with the `APP_PASSWORD`.
2. Trigger the OTP sending process through the respective UI or API call.
3. Verify that the OTP email is received at the specified recipient's email address.

