### PR TITLE
Add Change Password Feature with Error Handling

### DIFF
--- a/lib/core/depandancy_injection/service_locator.dart
+++ b/lib/core/depandancy_injection/service_locator.dart
@@ -10,12 +10,14 @@ import 'package:selaty/features/auth/domain/usecases/login_usecase.dart';
 import 'package:selaty/features/auth/domain/usecases/logout_usecase.dart';
 import 'package:selaty/features/auth/domain/usecases/register_usecase.dart';
 import 'package:selaty/features/auth/domain/usecases/send_otp_usecase.dart';
+import 'package:selaty/features/auth/domain/usecases/set_new_password_usecase.dart';
 import 'package:selaty/features/auth/presentation/logic/forget_password/send_otp_cubit.dart';
 import 'package:selaty/features/auth/presentation/logic/get_cached_user/get_cached_user_cubit.dart';
 import 'package:selaty/features/auth/presentation/logic/login/login_cubit.dart';
 import 'package:selaty/features/auth/presentation/logic/login_status/login_status_cubit.dart';
 import 'package:selaty/features/auth/presentation/logic/logout/logout_cubit.dart';
 import 'package:selaty/features/auth/presentation/logic/register/register_cubit.dart';
+import 'package:selaty/features/auth/presentation/logic/set_new_password/set_new_password_cubit.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final sl = GetIt.instance;
@@ -40,6 +42,8 @@ Future<void> setupServiceLocator() async {
   sl.registerLazySingleton<IsLoggedInUsecase>(() => IsLoggedInUsecase());
   sl.registerLazySingleton<LogoutUsecase>(() => LogoutUsecase());
   sl.registerLazySingleton<SendOtpUsecase>(() => SendOtpUsecase());
+  sl.registerLazySingleton<SetNewPasswordUsecase>(
+      () => SetNewPasswordUsecase());
 // cubits
   sl.registerFactory<RegisterCubit>(
     () => RegisterCubit(),
@@ -51,4 +55,5 @@ Future<void> setupServiceLocator() async {
   sl.registerFactory<LoginStatusCubit>(() => LoginStatusCubit());
   sl.registerFactory<LogoutCubit>(() => LogoutCubit());
   sl.registerFactory<SendOtpCubit>(() => SendOtpCubit());
+  sl.registerFactory<SetNewPasswordCubit>(() => SetNewPasswordCubit());
 }

--- a/lib/core/enums/status.dart
+++ b/lib/core/enums/status.dart
@@ -7,3 +7,5 @@ enum CachedUserStatus { initial, loading, loaded, error }
 enum LogoutStatus { initial, loading, success, error }
 
 enum ForgetPasswordStatus { initial, loading, success, error }
+
+enum SetNewPasswordStatus { initial, loading, success, error }

--- a/lib/features/auth/data/data_sources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/data_sources/auth_remote_data_source.dart
@@ -6,6 +6,8 @@ import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/core/helpers/dio_exception_helper.dart';
 import 'package:selaty/core/helpers/platform_exception_helper.dart';
 import 'package:selaty/core/network/dio_client.dart';
+import 'package:selaty/features/auth/data/models/change_password_req_body.dart';
+import 'package:selaty/features/auth/data/models/change_password_response.dart';
 import 'package:selaty/features/auth/data/models/login_req_body.dart';
 import 'package:selaty/features/auth/data/models/login_response.dart';
 import 'package:selaty/features/auth/data/models/register_req_body.dart';
@@ -18,7 +20,10 @@ abstract class AuthRemoteDataSource {
       {required RegisterReqBody registerReqBody});
   Future<Either<String, LoginUserData>> login(
       {required LoginReqBody loginReqBody});
-  Future<Either> sendOtp({required SendOtpReqBody forgetPasswordReqBody});
+  Future<Either<String, SendOtpResponseData>> sendOtp(
+      {required SendOtpReqBody forgetPasswordReqBody});
+  Future<Either<String, ChangePasswordResponseData>> setNewPassword(
+      {required ChangePasswordReqBody changePasswordReqBody});
 }
 
 class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
@@ -80,7 +85,6 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   }
 
   @override
-
   Future<Either<String, SendOtpResponseData>> sendOtp(
       {required SendOtpReqBody forgetPasswordReqBody}) async {
     try {
@@ -92,6 +96,41 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
         return Right(forgetPassResponse.data!);
       } else {
         return Left(forgetPassResponse.message);
+      }
+    } on DioException catch (e) {
+      // Handle the DioException using DioExceptionHelper
+      return Left(DioExceptionHelper.handleDioError(e));
+    } on PlatformException catch (e) {
+      // Handle the PlatformException using PlatformExceptionHelper
+      return Left(PlatformExceptionHelper.handlePlatformError(e));
+    } catch (e) {
+      return Left(
+          'حدث خطأ غير متوقع: $e'); // Arabic for "An unexpected error occurred"
+    }
+  }
+
+  @override
+  Future<Either<String, ChangePasswordResponseData>> setNewPassword(
+      {required ChangePasswordReqBody changePasswordReqBody}) async {
+    try {
+      String token = changePasswordReqBody.token;
+      var response = await sl<DioClient>().post(
+        ApiConstants.resetPasswordUrl,
+        data: changePasswordReqBody.toJson(),
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $token', // Add the token here
+            'Content-Type':
+                'application/json', // Optionally set the content type
+          },
+        ),
+      );
+      ChangePasswordResponse changePasswordResponse =
+          ChangePasswordResponse.fromJson(response.data);
+      if (changePasswordResponse.status) {
+        return Right(changePasswordResponse.data!);
+      } else {
+        return Left(changePasswordResponse.message);
       }
     } on DioException catch (e) {
       // Handle the DioException using DioExceptionHelper

--- a/lib/features/auth/data/models/change_password_response.dart
+++ b/lib/features/auth/data/models/change_password_response.dart
@@ -1,0 +1,76 @@
+import 'package:equatable/equatable.dart';
+
+class ChangePasswordResponse extends Equatable {
+  final bool status;
+  final String message;
+  final ChangePasswordResponseData? data;
+
+  const ChangePasswordResponse({
+    required this.status,
+    required this.message,
+    this.data,
+  });
+
+  factory ChangePasswordResponse.fromJson(Map<String, dynamic> json) {
+    return ChangePasswordResponse(
+      status: json['status'],
+      message: json['message'],
+      data: json['data'] != null ? ChangePasswordResponseData.fromJson(json['data']) : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'status': status,
+      'message': message,
+      'data': data?.toJson(),
+    };
+  }
+
+  @override
+  List<Object?> get props => [status, message, data];
+}
+
+class ChangePasswordResponseData extends Equatable {
+  final int id;
+  final String mobile;
+  final String email;
+  final String address;
+  final String userLang;
+  final String? profilePhotoUrl;
+
+  const ChangePasswordResponseData({
+    required this.id,
+    required this.mobile,
+    required this.email,
+    required this.address,
+    required this.userLang,
+    this.profilePhotoUrl,
+  });
+
+  factory ChangePasswordResponseData.fromJson(Map<String, dynamic> json) {
+    return ChangePasswordResponseData(
+      id: json['id'],
+      mobile: json['mobile'],
+      email: json['email'],
+      address: json['address'],
+      userLang: json['user_lang'],
+      profilePhotoUrl: json['profile_photo_url'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'mobile': mobile,
+      'email': email,
+      'address': address,
+      'user_lang': userLang,
+      'profile_photo_url': profilePhotoUrl,
+    };
+  }
+
+  @override
+  List<Object?> get props =>
+      [id, mobile, email, address, userLang, profilePhotoUrl];
+}

--- a/lib/features/auth/data/repository/auth_repo_impl.dart
+++ b/lib/features/auth/data/repository/auth_repo_impl.dart
@@ -1,7 +1,11 @@
 import 'package:dartz/dartz.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
+import 'package:selaty/core/helpers/send_mail_helper.dart';
 import 'package:selaty/features/auth/data/data_sources/auth_local_data_source.dart';
 import 'package:selaty/features/auth/data/data_sources/auth_remote_data_source.dart';
+import 'package:selaty/features/auth/data/models/change_password_req_body.dart';
+import 'package:selaty/features/auth/data/models/change_password_response.dart';
 import 'package:selaty/features/auth/data/models/login_req_body.dart';
 import 'package:selaty/features/auth/data/models/login_response.dart';
 import 'package:selaty/features/auth/data/models/register_req_body.dart';
@@ -57,15 +61,34 @@ class AuthRepoImpl implements AuthRepo {
   }
 
   @override
-  Future<Either<String,SendOtpResponseData>> sendOtp(
+  Future<Either<String, SendOtpResponseData>> sendOtp(
       {required SendOtpReqBody forgetPasswordReqBody}) async {
     final result = await sl<AuthRemoteDataSource>()
         .sendOtp(forgetPasswordReqBody: forgetPasswordReqBody);
     return result.fold(
       (error) => Left(error),
       (success) async {
-        
-        
+        String username = 'hmdy7486@gmail.com';
+        String password = dotenv.env['APP_PASSWORD'] ?? '';
+
+        final sendMailHelper =
+            SendMailHelper(username: username, password: password);
+        await sendMailHelper.sendOtpEmail(
+            success.email, success.newPassword.toString());
+
+        return Right(success);
+      },
+    );
+  }
+
+  @override
+  Future<Either<String, ChangePasswordResponseData>> setNewPassword(
+      {required ChangePasswordReqBody changePasswordReqBody}) async {
+    final result = await sl<AuthRemoteDataSource>()
+        .setNewPassword(changePasswordReqBody: changePasswordReqBody);
+    return result.fold(
+      (error) => Left(error),
+      (success) async {
         return Right(success);
       },
     );

--- a/lib/features/auth/domain/repository/auth_repo.dart
+++ b/lib/features/auth/domain/repository/auth_repo.dart
@@ -1,4 +1,6 @@
 import 'package:dartz/dartz.dart';
+import 'package:selaty/features/auth/data/models/change_password_req_body.dart';
+import 'package:selaty/features/auth/data/models/change_password_response.dart';
 import 'package:selaty/features/auth/data/models/login_req_body.dart';
 import 'package:selaty/features/auth/data/models/login_response.dart';
 import 'package:selaty/features/auth/data/models/register_req_body.dart';
@@ -13,4 +15,6 @@ abstract class AuthRepo {
   Future<bool> isLoggedIn();
   Future<Either<String, SendOtpResponseData>> sendOtp(
       {required SendOtpReqBody forgetPasswordReqBody});
+  Future<Either<String, ChangePasswordResponseData>> setNewPassword(
+      {required ChangePasswordReqBody changePasswordReqBody});
 }

--- a/lib/features/auth/domain/usecases/set_new_password_usecase.dart
+++ b/lib/features/auth/domain/usecases/set_new_password_usecase.dart
@@ -1,0 +1,25 @@
+import 'package:dartz/dartz.dart';
+import 'package:selaty/core/depandancy_injection/service_locator.dart';
+import 'package:selaty/core/usecase/usecase.dart';
+import 'package:selaty/features/auth/data/models/change_password_req_body.dart';
+import 'package:selaty/features/auth/data/models/change_password_response.dart';
+import 'package:selaty/features/auth/domain/repository/auth_repo.dart';
+
+class SetNewPasswordUsecase extends UseCase<Either, SetNewPasswordParms> {
+  @override
+  Future<Either<String, ChangePasswordResponseData>> call(
+      {SetNewPasswordParms? param}) async {
+    if (param == null) {
+      throw ArgumentError('SetNewPasswordParms cannot be null');
+    }
+
+    return await sl<AuthRepo>()
+        .setNewPassword(changePasswordReqBody: param.changePasswordReqBody);
+  }
+}
+
+class SetNewPasswordParms {
+  final ChangePasswordReqBody changePasswordReqBody;
+
+  SetNewPasswordParms({required this.changePasswordReqBody});
+}

--- a/lib/features/auth/presentation/logic/forget_password/send_otp_cubit.dart
+++ b/lib/features/auth/presentation/logic/forget_password/send_otp_cubit.dart
@@ -1,11 +1,8 @@
 import 'package:dartz/dartz.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart'; // Import dotenv
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/core/enums/status.dart';
-import 'package:selaty/core/helpers/send_mail_helper.dart';
 import 'package:selaty/features/auth/data/models/send_otp_req_body.dart';
-import 'package:selaty/features/auth/data/models/send_otp_response.dart'; // Adjust the path as needed
 import 'package:selaty/features/auth/domain/usecases/send_otp_usecase.dart';
 import 'package:selaty/features/auth/presentation/logic/forget_password/send_otp_state.dart';
 
@@ -24,20 +21,8 @@ class SendOtpCubit extends Cubit<SendOtpState> {
       (success) async {
         emit(state.copyWith(
             status: ForgetPasswordStatus.success, response: success));
-
-        await sendOtpEmail(success);
       },
     );
-  }
-
-  Future<void> sendOtpEmail(SendOtpResponseData response) async {
-    String username = 'hmdy7486@gmail.com';
-    String password = dotenv.env['APP_PASSWORD'] ?? '';
-
-    final sendMailHelper =
-        SendMailHelper(username: username, password: password);
-    await sendMailHelper.sendOtpEmail(
-        response.email, response.newPassword.toString());
   }
 
   void reset() {

--- a/lib/features/auth/presentation/logic/set_new_password/set_new_password_cubit.dart
+++ b/lib/features/auth/presentation/logic/set_new_password/set_new_password_cubit.dart
@@ -1,0 +1,37 @@
+import 'package:dartz/dartz.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:selaty/core/depandancy_injection/service_locator.dart';
+import 'package:selaty/core/enums/status.dart';
+import 'package:selaty/features/auth/data/models/change_password_req_body.dart';
+import 'package:selaty/features/auth/data/models/change_password_response.dart';
+import 'package:selaty/features/auth/domain/usecases/set_new_password_usecase.dart';
+import 'package:selaty/features/auth/presentation/logic/set_new_password/set_new_password_state.dart';
+
+class SetNewPasswordCubit extends Cubit<SetNewPasswordState> {
+  SetNewPasswordCubit() : super(const SetNewPasswordState());
+
+  Future<void> setNewPassword(
+      ChangePasswordReqBody changePasswordReqBody) async {
+    emit(state.copyWith(status: SetNewPasswordStatus.loading));
+
+    final Either<String, ChangePasswordResponseData> result =
+        await sl<SetNewPasswordUsecase>().call(
+      param: SetNewPasswordParms(changePasswordReqBody: changePasswordReqBody),
+    );
+
+    result.fold(
+      (failure) => emit(
+          state.copyWith(status: SetNewPasswordStatus.error, message: failure)),
+      (success) async {
+        emit(state.copyWith(
+          status: SetNewPasswordStatus.success,
+          response: success,
+        ));
+      },
+    );
+  }
+
+  void reset() {
+    emit(const SetNewPasswordState());
+  }
+}

--- a/lib/features/auth/presentation/logic/set_new_password/set_new_password_state.dart
+++ b/lib/features/auth/presentation/logic/set_new_password/set_new_password_state.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+import 'package:selaty/core/enums/status.dart';
+import 'package:selaty/features/auth/data/models/change_password_response.dart';
+
+class SetNewPasswordState extends Equatable {
+  final SetNewPasswordStatus status;
+  final ChangePasswordResponseData?
+      response; // Holds the entire response object
+  final String? message;
+
+  const SetNewPasswordState({
+    this.status = SetNewPasswordStatus.initial,
+    this.response,
+    this.message,
+  });
+
+  SetNewPasswordState copyWith({
+    SetNewPasswordStatus? status,
+    ChangePasswordResponseData? response,
+    String? message,
+  }) {
+    return SetNewPasswordState(
+      status: status ?? this.status,
+      response: response ?? this.response,
+      message: message ?? this.message,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, response, message];
+}

--- a/lib/features/auth/presentation/views/new_password_view.dart
+++ b/lib/features/auth/presentation/views/new_password_view.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:selaty/core/common/widgets/custom_app_bar.dart';
 import 'package:selaty/core/common/widgets/password_text_field.dart';
 import 'package:selaty/core/common/widgets/primary_button.dart';
 import 'package:selaty/core/constants/colors.dart';
 import 'package:selaty/core/constants/styles.dart';
+import 'package:selaty/core/enums/status.dart';
 import 'package:selaty/core/helpers/helper_functions.dart';
+import 'package:selaty/features/auth/data/models/change_password_req_body.dart';
+import 'package:selaty/features/auth/presentation/logic/set_new_password/set_new_password_cubit.dart';
+import 'package:selaty/features/auth/presentation/logic/set_new_password/set_new_password_state.dart';
 import 'package:selaty/features/auth/presentation/views/password_changed_successfully.dart';
 
 class NewPasswordView extends StatefulWidget {
@@ -30,23 +35,6 @@ class _NewPasswordViewState extends State<NewPasswordView> {
     super.dispose();
   }
 
-  void _submitNewPassword() {
-    if (_formKey.currentState!.validate()) {
-      if (_passwordController.text == _confirmPasswordController.text) {
-        _formKey.currentState!.save();
-        THelperFunctions.showSnackBar(
-            context: context, message: 'تم تغيير كلمة المرور بنجاح');
-        Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(
-                builder: (context) => const PasswordChangedSuccessfullyView()));
-      } else {
-        THelperFunctions.showSnackBar(
-            context: context, message: 'كلمة المرور غير متطابقة');
-      }
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.of(context).size;
@@ -59,49 +47,95 @@ class _NewPasswordViewState extends State<NewPasswordView> {
     final spacing = size.height * 0.02;
     final largeSpacing = size.height * 0.04;
 
-    return Scaffold(
-      backgroundColor: const Color(0xffFDFDFF),
-      appBar: CustomAppBar(
-        onPressed: () => Navigator.pop(context),
-        title: 'تعيين كلمة مرور جديدة',
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          child: Padding(
-            padding: EdgeInsets.symmetric(
-              horizontal: horizontalPadding,
-              vertical: verticalPadding,
-            ),
-            child: Form(
-              key: _formKey,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    'الرجاء إدخال كلمة المرور الجديدة',
-                    style: Styles.textStyle16.copyWith(color: Colors.grey),
-                    textAlign: TextAlign.right,
-                  ),
-                  SizedBox(height: largeSpacing),
-                  PasswordTextFormField(
-                    text: 'كلمة المرور الجديدة',
-                    width: double.infinity,
-                    controller: _passwordController,
-                  ),
-                  SizedBox(height: spacing),
-                  PasswordTextFormField(
-                    text: 'تأكيد كلمة المرور الجديدة',
-                    width: double.infinity,
-                    controller: _confirmPasswordController,
-                  ),
-                  SizedBox(height: largeSpacing),
-                  PrimaryButton(
-                    text: 'تعيين كلمة المرور الجديدة',
-                    color: primaryGreen,
-                    onTap: _submitNewPassword,
-                    width: double.infinity,
-                  ),
-                ],
+    return BlocListener<SetNewPasswordCubit, SetNewPasswordState>(
+      listener: (context, state) {
+        if (state.status == SetNewPasswordStatus.success) {
+          THelperFunctions.showSnackBar(
+              context: context, message: "تم تغيير كلمة المرور بنجاح");
+          Future.delayed(const Duration(microseconds: 500));
+          Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(
+                builder: (context) => const PasswordChangedSuccessfullyView()),
+          );
+        }
+        if (state.status == SetNewPasswordStatus.error) {
+          THelperFunctions.showSnackBar(
+              context: context, message: state.message!);
+        }
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xffFDFDFF),
+        appBar: CustomAppBar(
+          onPressed: () => Navigator.pop(context),
+          title: 'تعيين كلمة مرور جديدة',
+        ),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: horizontalPadding,
+                vertical: verticalPadding,
+              ),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      'الرجاء إدخال كلمة المرور الجديدة',
+                      style: Styles.textStyle16.copyWith(color: Colors.grey),
+                      textAlign: TextAlign.right,
+                    ),
+                    SizedBox(height: largeSpacing),
+                    PasswordTextFormField(
+                      text: 'كلمة المرور الجديدة',
+                      width: double.infinity,
+                      controller: _passwordController,
+                    ),
+                    SizedBox(height: spacing),
+                    PasswordTextFormField(
+                      text: 'تأكيد كلمة المرور الجديدة',
+                      width: double.infinity,
+                      controller: _confirmPasswordController,
+                    ),
+                    SizedBox(height: largeSpacing),
+                    BlocBuilder<SetNewPasswordCubit, SetNewPasswordState>(
+                      builder: (context, state) {
+                        return PrimaryButton(
+                          text: state.status == ForgetPasswordStatus.loading
+                              ? 'جاري تعيين كلمة المرور الجديدة ...'
+                              : 'تعيين كلمة المرور الجديدة',
+                          color: primaryGreen,
+                          onTap: () {
+                            if (state.status != ForgetPasswordStatus.loading &&
+                                _formKey.currentState!.validate()) {
+                              if (_passwordController.text ==
+                                  _confirmPasswordController.text) {
+                                _formKey.currentState!.save();
+                                context
+                                    .read<SetNewPasswordCubit>()
+                                    .setNewPassword(ChangePasswordReqBody(
+                                        otp: widget.otp.toString(),
+                                        token: widget.token,
+                                        newPassword:
+                                            _passwordController.text.trim(),
+                                        confirmPassword:
+                                            _confirmPasswordController.text
+                                                .trim()));
+                              } else {
+                                THelperFunctions.showSnackBar(
+                                    context: context,
+                                    message: 'كلمة المرور غير متطابقة');
+                              }
+                            }
+                          },
+                          width: double.infinity,
+                        );
+                      },
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/features/auth/presentation/views/otp_view.dart
+++ b/lib/features/auth/presentation/views/otp_view.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
 import 'package:selaty/core/common/widgets/custom_app_bar.dart';
 import 'package:selaty/core/common/widgets/primary_button.dart';
 import 'package:selaty/core/constants/colors.dart';
 import 'package:selaty/core/constants/styles.dart';
+import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/core/helpers/helper_functions.dart';
+import 'package:selaty/features/auth/presentation/logic/set_new_password/set_new_password_cubit.dart';
 import 'package:selaty/features/auth/presentation/views/new_password_view.dart';
 
 class OtpView extends StatefulWidget {
@@ -125,9 +128,12 @@ class _OtpViewState extends State<OtpView> {
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
-            builder: (context) => NewPasswordView(
-                  otp: widget.otp,
-                  token: widget.token,
+            builder: (context) => BlocProvider(
+                  create: (context) => sl<SetNewPasswordCubit>(),
+                  child: NewPasswordView(
+                    otp: widget.otp,
+                    token: widget.token,
+                  ),
                 )),
       );
     } else {

--- a/lib/features/auth/presentation/views/password_changed_successfully.dart
+++ b/lib/features/auth/presentation/views/password_changed_successfully.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:selaty/core/common/widgets/custom_app_bar.dart';
 import 'package:selaty/core/common/widgets/primary_button.dart';
 import 'package:selaty/core/constants/colors.dart';
 import 'package:selaty/core/constants/styles.dart';
+import 'package:selaty/core/depandancy_injection/service_locator.dart';
+import 'package:selaty/features/auth/presentation/logic/login/login_cubit.dart';
 import 'package:selaty/features/auth/presentation/views/login_view.dart';
 
 class PasswordChangedSuccessfullyView extends StatelessWidget {
@@ -66,8 +69,10 @@ class PasswordChangedSuccessfullyView extends StatelessWidget {
                 onTap: () {
                   Navigator.of(context).pushAndRemoveUntil(
                     MaterialPageRoute(
-                      builder: (context) => const LoginView(),
-                    ),
+                        builder: (context) => BlocProvider(
+                              create: (context) => sl<LoginCubit>(),
+                              child: const LoginView(),
+                            )),
                     (Route<dynamic> route) => false,
                   );
                 },


### PR DESCRIPTION
### Summary
This pull request implements the change password functionality in the application. It includes the following:

- **Cubit**: Created `SetNewPasswordCubit` to manage the change password state.
- **UseCase**: Added `SetNewPasswordUsecase` for handling business logic related to password changes.
- **Repository**: Implemented `changePassword` method in `AuthRepoImpl` to interact with the remote data source.
- **Remote Data Source**: Created `setNewPassword` method in `AuthRemoteDataSourceImpl` to make API calls for changing the password.
- **Error Handling**: Implemented error handling using `Either` for success and failure scenarios, returning appropriate messages.

### Changes Made
- Added `SetNewPasswordState` for managing the state during the password change process.
- Updated the `AuthRepo` and `AuthRemoteDataSource` interfaces to include the new functionality.
- Ensured that API responses are correctly processed, and errors are handled gracefully with messages in Arabic for better user experience.

### Testing
- Please test the change password functionality to ensure that all scenarios, including success and failure, are handled correctly.
