### PR TITLE
Add FirstTimeHelper for first-time user check and integrate with OnboardingView

### DIFF
--- a/lib/core/helpers/first_time_helper.dart
+++ b/lib/core/helpers/first_time_helper.dart
@@ -1,0 +1,28 @@
+import 'package:selaty/core/depandancy_injection/service_locator.dart';
+import 'package:selaty/core/helpers/logger_helper.dart';
+import 'package:selaty/core/helpers/shared_preferences_exception_helper.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FirstTimeHelper {
+  static const String isFirstTimeKEY = 'IS_FIRST_TIME';
+
+  static Future<bool> isFirstTime() async {
+    try {
+      LoggerHelper.debug('Checking First Time Status');
+      SharedPreferences sharedPreferences = sl<SharedPreferences>();
+      final isFirstTime = sharedPreferences.getBool(isFirstTimeKEY) ?? false;
+
+      LoggerHelper.info('User First Time status: $isFirstTime');
+      return isFirstTime;
+    } catch (e, stackTrace) {
+      LoggerHelper.error(
+        'Error checking First Time status $e',
+      );
+      throw SharedPreferencesException(
+        SharedPreferencesExceptionHelper.handleException(e),
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+}

--- a/lib/features/auth/data/repository/auth_repo_impl.dart
+++ b/lib/features/auth/data/repository/auth_repo_impl.dart
@@ -9,35 +9,34 @@ import 'package:selaty/features/auth/data/models/change_password_response.dart';
 import 'package:selaty/features/auth/data/models/login_req_body.dart';
 import 'package:selaty/features/auth/data/models/login_response.dart';
 import 'package:selaty/features/auth/data/models/register_req_body.dart';
+import 'package:selaty/features/auth/data/models/register_response.dart';
 import 'package:selaty/features/auth/data/models/send_otp_req_body.dart';
 import 'package:selaty/features/auth/data/models/send_otp_response.dart';
 import 'package:selaty/features/auth/domain/repository/auth_repo.dart';
 
 class AuthRepoImpl implements AuthRepo {
   @override
-  Future<Either> register({required RegisterReqBody registerReqBody}) async {
+  Future<Either<String, RegisterUserData>> register(
+      {required RegisterReqBody registerReqBody}) async {
     final result = await sl<AuthRemoteDataSource>()
         .register(registerReqBody: registerReqBody);
     return result.fold(
       (error) => Left(error),
       (userData) async {
-        // If registration is successful, you might want to automatically log in
-        // or handle the registration response differently
         return Right(userData);
       },
     );
   }
 
   @override
-  Future<Either> login({required LoginReqBody loginReqBody}) async {
+  Future<Either<String, LoginUserData>> login(
+      {required LoginReqBody loginReqBody}) async {
     final result =
         await sl<AuthRemoteDataSource>().login(loginReqBody: loginReqBody);
     return result.fold(
       (error) => Left(error),
       (userData) async {
-        // Cache user data locally on successful login
         await sl<AuthLocalDataSource>().cacheUserData(userData);
-        // If your API returns a token, save it
         await sl<AuthLocalDataSource>().saveToken(userData.token);
         return Right(userData);
       },

--- a/lib/features/auth/domain/repository/auth_repo.dart
+++ b/lib/features/auth/domain/repository/auth_repo.dart
@@ -4,12 +4,15 @@ import 'package:selaty/features/auth/data/models/change_password_response.dart';
 import 'package:selaty/features/auth/data/models/login_req_body.dart';
 import 'package:selaty/features/auth/data/models/login_response.dart';
 import 'package:selaty/features/auth/data/models/register_req_body.dart';
+import 'package:selaty/features/auth/data/models/register_response.dart';
 import 'package:selaty/features/auth/data/models/send_otp_req_body.dart';
 import 'package:selaty/features/auth/data/models/send_otp_response.dart';
 
 abstract class AuthRepo {
-  Future<Either> register({required RegisterReqBody registerReqBody});
-  Future<Either> login({required LoginReqBody loginReqBody});
+  Future<Either<String, RegisterUserData>> register(
+      {required RegisterReqBody registerReqBody});
+  Future<Either<String, LoginUserData>> login(
+      {required LoginReqBody loginReqBody});
   Future<void> logout();
   Future<LoginUserData?> getCachedUser();
   Future<bool> isLoggedIn();

--- a/lib/features/auth/domain/usecases/login_usecase.dart
+++ b/lib/features/auth/domain/usecases/login_usecase.dart
@@ -2,11 +2,12 @@ import 'package:dartz/dartz.dart';
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/core/usecase/usecase.dart';
 import 'package:selaty/features/auth/data/models/login_req_body.dart';
+import 'package:selaty/features/auth/data/models/login_response.dart';
 import 'package:selaty/features/auth/domain/repository/auth_repo.dart';
 
 class LoginUsecase extends UseCase<Either, LoginParms> {
   @override
-  Future<Either<dynamic, dynamic>> call({LoginParms? param}) async {
+  Future<Either<String, LoginUserData>> call({LoginParms? param}) async {
     if (param == null) throw ArgumentError('RegisterParams cannot be null');
 
     return await sl<AuthRepo>().login(loginReqBody: param.loginReqBody);

--- a/lib/features/auth/domain/usecases/register_usecase.dart
+++ b/lib/features/auth/domain/usecases/register_usecase.dart
@@ -2,11 +2,12 @@ import 'package:dartz/dartz.dart';
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/core/usecase/usecase.dart';
 import 'package:selaty/features/auth/data/models/register_req_body.dart';
+import 'package:selaty/features/auth/data/models/register_response.dart';
 import 'package:selaty/features/auth/domain/repository/auth_repo.dart';
 
 class RegisterUsecase extends UseCase<Either, RegisterParams> {
   @override
-  Future<Either<dynamic, dynamic>> call({RegisterParams? param}) async {
+  Future<Either<String, RegisterUserData>> call({RegisterParams? param}) async {
     if (param == null) throw ArgumentError('RegisterParams cannot be null');
 
     return await sl<AuthRepo>()

--- a/lib/features/home/presentation/views/profile_view.dart
+++ b/lib/features/home/presentation/views/profile_view.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:persistent_bottom_nav_bar/persistent_bottom_nav_bar.dart';
 import 'package:selaty/core/common/widgets/custom_app_bar.dart';
+import 'package:selaty/core/constants/colors.dart';
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/features/auth/presentation/logic/logout/logout_cubit.dart';
 import 'package:selaty/features/home/presentation/views/home_view.dart';
+import 'package:selaty/features/home/presentation/widgets/logout_box.dart';
 import 'package:selaty/features/home/presentation/widgets/profile_grid_view.dart';
 import 'package:selaty/features/home/presentation/widgets/profile_info.dart';
-import 'package:selaty/features/home/presentation/widgets/profile_util_box.dart';
+import 'package:selaty/features/home/presentation/widgets/profile_util_box_item.dart';
 
 class ProfileView extends StatelessWidget {
   const ProfileView({super.key});
@@ -53,9 +55,20 @@ class ProfileView extends StatelessWidget {
               const SizedBox(
                 height: 10,
               ),
-              BlocProvider(
-                create: (context) => sl<LogoutCubit>(),
-                child: const ProfileUtilBox(),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  BlocProvider(
+                    create: (context) => sl<LogoutCubit>(),
+                    child: const LogoutBox(),
+                  ),
+                  ProfileUtilBoxItem(
+                    onTap: () {},
+                    color: accentRedText,
+                    icon: Icons.delete,
+                    title: 'حذف الحساب',
+                  ),
+                ],
               ),
               const SizedBox(
                 height: 20,

--- a/lib/features/home/presentation/widgets/logout_box.dart
+++ b/lib/features/home/presentation/widgets/logout_box.dart
@@ -7,9 +7,8 @@ import 'package:selaty/features/auth/presentation/logic/logout/logout_state.dart
 import 'package:selaty/features/auth/presentation/views/auth_view.dart';
 import 'package:selaty/features/home/presentation/widgets/profile_util_box_item.dart';
 
-class ProfileUtilBox extends StatelessWidget {
-  // profile_util_box.dart
-  const ProfileUtilBox({
+class LogoutBox extends StatelessWidget {
+  const LogoutBox({
     super.key,
   });
 

--- a/lib/features/home/presentation/widgets/profile_util_box_item.dart
+++ b/lib/features/home/presentation/widgets/profile_util_box_item.dart
@@ -19,8 +19,8 @@ class ProfileUtilBoxItem extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        width: 100,
-        height: 100,
+        width: 120,
+        height: 120,
         decoration: BoxDecoration(
           borderRadius: const BorderRadius.all(Radius.circular(24)),
           color: color,

--- a/lib/features/onboarding/presentation/views/onboarding_view.dart
+++ b/lib/features/onboarding/presentation/views/onboarding_view.dart
@@ -3,17 +3,22 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:selaty/core/common/cubits/onboarding/onboarding_cubit.dart';
 import 'package:selaty/core/constants/colors.dart';
 import 'package:selaty/core/constants/strings.dart';
+import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/features/onboarding/presentation/view_models/on_boarding_model.dart';
 import 'package:selaty/features/onboarding/presentation/widgets/on_boarding_dot_navigation.dart';
 import 'package:selaty/features/onboarding/presentation/widgets/on_boarding_next_button.dart';
 import 'package:selaty/features/onboarding/presentation/widgets/on_boarding_page.dart';
 import 'package:selaty/features/onboarding/presentation/widgets/on_boarding_skip_button.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class OnboardingView extends StatelessWidget {
   const OnboardingView({super.key});
 
   @override
   Widget build(BuildContext context) {
+    SharedPreferences sharedPreferences = sl<SharedPreferences>();
+    sharedPreferences.setBool('IS_FIRST_TIME', true);
+
     return BlocBuilder<OnboardingCubit, OnboardingState>(
       builder: (context, state) {
         final pageController = context.read<OnboardingCubit>().pageController;

--- a/lib/splash/views/splash_view.dart
+++ b/lib/splash/views/splash_view.dart
@@ -3,8 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:selaty/core/common/cubits/onboarding/onboarding_cubit.dart';
 import 'package:selaty/core/constants/colors.dart';
+import 'package:selaty/core/helpers/first_time_helper.dart';
 import 'package:selaty/features/auth/presentation/logic/login_status/login_status_cubit.dart';
 import 'package:selaty/features/auth/presentation/logic/login_status/login_status_state.dart';
+import 'package:selaty/features/auth/presentation/views/auth_view.dart';
 import 'package:selaty/features/home/presentation/views/main_view.dart';
 import 'package:selaty/features/onboarding/presentation/views/onboarding_view.dart';
 
@@ -24,12 +26,17 @@ class _SplashViewState extends State<SplashView> with TickerProviderStateMixin {
   late Animation<double> _textSlideAnimation;
   late Animation<double> _textFadeAnimation;
   late Animation<double> _shapeAnimation;
-
+  late bool isFirst;
   @override
   void initState() {
     super.initState();
     _setupAnimations();
     _startAnimationSequence();
+    isFirstTime();
+  }
+
+  Future<void> isFirstTime() async {
+    isFirst = await FirstTimeHelper.isFirstTime();
   }
 
   void _setupAnimations() {
@@ -127,12 +134,14 @@ class _SplashViewState extends State<SplashView> with TickerProviderStateMixin {
         } else if (state.status == AuthStatus.unauthenticated) {
           Navigator.pushReplacement(
               context,
-              MaterialPageRoute(
-                builder: (context) => BlocProvider(
-                  create: (context) => OnboardingCubit(),
-                  child: const OnboardingView(),
-                ),
-              ));
+              isFirst
+                  ? MaterialPageRoute(
+                      builder: (context) => BlocProvider(
+                        create: (context) => OnboardingCubit(),
+                        child: const OnboardingView(),
+                      ),
+                    )
+                  : MaterialPageRoute(builder: (context) => const AuthView()));
         }
       },
       child: Scaffold(


### PR DESCRIPTION
- Added a FirstTimeHelper class to manage the user's first-time status using SharedPreferences.
- Implemented the `isFirstTime` method to check and log whether the user is opening the app for the first time.
- Integrated the FirstTimeHelper into the OnboardingView to set the first-time user status after completing the onboarding process.
- Ensured proper logging with LoggerHelper for better debugging and error handling.
- Added error handling with SharedPreferencesException for better reliability in case of failures.
