### PR TITLE
Add Use Case and Cubit for Fetching Category Names for Products

### DIFF
--- a/lib/core/depandancy_injection/service_locator.dart
+++ b/lib/core/depandancy_injection/service_locator.dart
@@ -23,12 +23,13 @@ import 'package:selaty/features/home/data/data_sources/home_remote_data_source.d
 import 'package:selaty/features/home/data/repository/home_repo_impl.dart';
 import 'package:selaty/features/home/domain/repository/home_repo.dart';
 import 'package:selaty/features/home/domain/usecases/get_categories_usecase.dart';
+import 'package:selaty/features/home/domain/usecases/get_category_name_for_product_usecase.dart';
 import 'package:selaty/features/home/domain/usecases/get_products_usecase.dart';
 import 'package:selaty/features/home/domain/usecases/get_slider_images_usecase.dart';
 import 'package:selaty/features/home/presentation/logic/categories_cubit.dart';
+import 'package:selaty/features/home/presentation/logic/category_name_for_product_cubit.dart';
 import 'package:selaty/features/home/presentation/logic/product_cubit.dart';
 import 'package:selaty/features/home/presentation/logic/slider_images_cubit.dart';
-import 'package:selaty/features/home/presentation/widgets/product_card.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final sl = GetIt.instance;
@@ -77,9 +78,11 @@ Future<void> setupServiceLocator() async {
       () => GetSliderImagesUseCase());
   sl.registerLazySingleton<GetCategoriesUsecase>(() => GetCategoriesUsecase());
   sl.registerLazySingleton<GetProductsUsecase>(() => GetProductsUsecase());
+  sl.registerLazySingleton<GetCategoryNamesForProductsUsecase>(
+      () => GetCategoryNamesForProductsUsecase());
 //home cubits
   sl.registerFactory<SliderImagesCubit>(() => SliderImagesCubit());
   sl.registerFactory<CategoriesCubit>(() => CategoriesCubit());
   sl.registerFactory<ProductCubit>(() => ProductCubit());
+  sl.registerFactory<CategoryNameCubit>(() => CategoryNameCubit());
 }
-

--- a/lib/core/enums/status.dart
+++ b/lib/core/enums/status.dart
@@ -13,4 +13,7 @@ enum SetNewPasswordStatus { initial, loading, success, failure }
 enum SliderImagesStatus { initial, loading, success, failure }
 
 enum CategoriesStatus { initial, loading, success, failure }
+
 enum ProductStatus { initial, loading, success, failure }
+
+enum CategoryNameStatus { initial, loading, success, failure }

--- a/lib/features/home/data/data_sources/home_local_data_source.dart
+++ b/lib/features/home/data/data_sources/home_local_data_source.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:dartz/dartz.dart';
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/core/helpers/logger_helper.dart';
+import 'package:selaty/features/home/data/models/categories_response.dart';
+import 'package:selaty/features/home/data/models/product_reesponse_model.dart';
 import 'package:selaty/features/home/data/models/slider_response.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -10,6 +12,12 @@ abstract class HomeLocalDataSource {
   Future<Either<String, List<SliderResponseData>>> getSliderImages();
   Future<Either<String, void>> cacheSliderImages(
       List<SliderResponseData> images);
+  Future<Either<String, List<Category>>> getCategories();
+  Future<Either<String, void>> cacheCategories(List<Category> categories);
+  Future<Either<String, List<Product>>> getProducts();
+  Future<Either<String, void>> cacheProducts(List<Product> products);
+
+  Future<Either<String, void>> clearCache();
 }
 
 class HomeLocalDataSourceImpl implements HomeLocalDataSource {
@@ -46,6 +54,87 @@ class HomeLocalDataSourceImpl implements HomeLocalDataSource {
     } catch (e) {
       LoggerHelper.error("Failed to cache images: $e");
       return const Left("Failed to cache images");
+    }
+  }
+
+  @override
+  Future<Either<String, void>> cacheCategories(
+      List<Category> categories) async {
+    try {
+      final jsonString =
+          json.encode(categories.map((category) => category.toJson()).toList());
+      sl<SharedPreferences>().setString('categories', jsonString);
+      LoggerHelper.info("Cached categories in Shared Preferences");
+      return const Right(null);
+    } catch (e) {
+      LoggerHelper.error("Failed to cache Categories: $e");
+      return const Left("Failed to cache Categories");
+    }
+  }
+
+  @override
+  Future<Either<String, List<Category>>> getCategories() async {
+    try {
+      final jsonString = sl<SharedPreferences>().getString('categories');
+      if (jsonString != null) {
+        final List<dynamic> jsonList = json.decode(jsonString);
+        final List<Category> categories =
+            jsonList.map((json) => Category.fromJson(json)).toList();
+        LoggerHelper.info("Loaded cached categories from Shared Preferences");
+        return Right(categories);
+      } else {
+        LoggerHelper.warning("No cached categories found");
+        return const Left("No cached categories found");
+      }
+    } catch (e) {
+      LoggerHelper.error("Failed to decode cached categories: $e");
+      return const Left("Failed to decode cached categories");
+    }
+  }
+
+  @override
+  Future<Either<String, void>> clearCache() async {
+    try {
+      sl<SharedPreferences>().remove('slider_images');
+      sl<SharedPreferences>().remove('categories');
+      return const Right(null);
+    } catch (e) {
+      LoggerHelper.error("Failed to clear cache: $e");
+      return const Left("Failed to clear cache");
+    }
+  }
+
+  @override
+  Future<Either<String, List<Product>>> getProducts() async {
+    try {
+      final jsonString = sl<SharedPreferences>().getString('products');
+      if (jsonString != null) {
+        final List<dynamic> jsonList = json.decode(jsonString);
+        final List<Product> products =
+            jsonList.map((json) => Product.fromJson(json)).toList();
+        LoggerHelper.info("Loaded cached products from Shared Preferences");
+        return Right(products);
+      } else {
+        LoggerHelper.warning("No cached products found");
+        return const Left("No cached products found");
+      }
+    } catch (e) {
+      LoggerHelper.error("Failed to decode cached products: $e");
+      return const Left("Failed to decode cached products");
+    }
+  }
+
+  @override
+  Future<Either<String, void>> cacheProducts(List<Product> products) async {
+    try {
+      final jsonString =
+          json.encode(products.map((product) => product.toJson()).toList());
+      sl<SharedPreferences>().setString('products', jsonString);
+      LoggerHelper.info("Cached products in Shared Preferences");
+      return const Right(null);
+    } catch (e) {
+      LoggerHelper.error("Failed to cache products: $e");
+      return const Left("Failed to cache products");
     }
   }
 }

--- a/lib/features/home/data/models/product_reesponse_model.dart
+++ b/lib/features/home/data/models/product_reesponse_model.dart
@@ -52,6 +52,7 @@ class ProductData {
 }
 
 class Product {
+  String?categoryName;
   int id;
   int userId;
   int type;

--- a/lib/features/home/data/repository/home_repo_impl.dart
+++ b/lib/features/home/data/repository/home_repo_impl.dart
@@ -10,24 +10,147 @@ import 'package:selaty/features/home/domain/repository/home_repo.dart';
 class HomeRepoImpl extends HomeRepo {
   @override
   Future<Either<String, List<SliderResponseData>>> getSliderImages() async {
-    final result = await sl<HomeRemoteDataSource>().getSliderImages();
-    return result.fold(
-      (error) => Left(error),
-      (sliderResponse) async {
-        sl<HomeLocalDataSource>().cacheSliderImages;
-
-        return Right(sliderResponse);
+    final localResult = await sl<HomeLocalDataSource>().getSliderImages();
+    return localResult.fold(
+      (error) async {
+        final remoteResult = await sl<HomeRemoteDataSource>().getSliderImages();
+        return remoteResult.fold(
+          (error) => Left(error),
+          (sliderImages) async {
+            sl<HomeLocalDataSource>().cacheSliderImages(sliderImages);
+            return Right(sliderImages);
+          },
+        );
+      },
+      (sliderImages) async {
+        if (sliderImages.isEmpty) {
+          final remoteResult =
+              await sl<HomeRemoteDataSource>().getSliderImages();
+          return remoteResult.fold(
+            (error) => Left(error),
+            (sliderImages) async {
+              sl<HomeLocalDataSource>().cacheSliderImages(sliderImages);
+              return Right(sliderImages);
+            },
+          );
+        } else {
+          return Right(sliderImages);
+        }
       },
     );
   }
 
   @override
   Future<Either<String, List<Category>>> getCategories() async {
-    return await sl<HomeRemoteDataSource>().getCategories();
+    final localResult = await sl<HomeLocalDataSource>().getCategories();
+
+    return localResult.fold(
+      (error) async {
+        final remoteResult = await sl<HomeRemoteDataSource>().getCategories();
+        return remoteResult.fold(
+          (error) => Left(error),
+          (categories) async {
+            sl<HomeLocalDataSource>().cacheCategories(categories);
+            return Right(categories);
+          },
+        );
+      },
+      (categories) async {
+        if (categories.isEmpty) {
+          final remoteResult = await sl<HomeRemoteDataSource>().getCategories();
+          return remoteResult.fold(
+            (error) => Left(error),
+            (categories) async {
+              sl<HomeLocalDataSource>().cacheCategories(categories);
+              return Right(categories);
+            },
+          );
+        } else {
+          return Right(categories);
+        }
+      },
+    );
   }
 
   @override
   Future<Either<String, List<Product>>> getProducts({required int page}) async {
-    return await sl<HomeRemoteDataSource>().getProducts(page: page);
+    final localResult = await sl<HomeLocalDataSource>().getProducts();
+    return localResult.fold(
+      (error) async {
+        final remoteResult =
+            await sl<HomeRemoteDataSource>().getProducts(page: page);
+        return remoteResult.fold(
+          (error) => Left(error),
+          (products) async {
+            sl<HomeLocalDataSource>().cacheProducts(products);
+            return Right(products);
+          },
+        );
+      },
+      (products) async {
+        if (products.isEmpty) {
+          final remoteResult =
+              await sl<HomeRemoteDataSource>().getProducts(page: page);
+          return remoteResult.fold((error) => Left(error), (products) async {
+            sl<HomeLocalDataSource>().cacheProducts(products);
+            return Right(products);
+          });
+        } else {
+          return Right(products);
+        }
+      },
+    );
+  }
+
+  @override
+  Future<Either<String, List<String>>> getCategoryNamesForProducts(
+      List<Product> products) async {
+    // Fetch categories from the local data source
+    final localResult = await sl<HomeLocalDataSource>().getCategories();
+
+    return localResult.fold(
+      (error) async {
+        // If there's an error fetching local categories, fetch from remote
+        final remoteResult = await sl<HomeRemoteDataSource>().getCategories();
+        return remoteResult.fold(
+          (error) => Left(error), // Return the error
+          (categories) async {
+            // Cache the categories locally
+            sl<HomeLocalDataSource>().cacheCategories(categories);
+
+            // Create a list to hold the category names for the given products
+            List<String> categoryNames = [];
+
+            // Find category names for each product
+            for (var product in products) {
+              final category = categories.firstWhere(
+                (cat) =>
+                    cat.id ==
+                    product.categoryId, // Assuming product has categoryId
+                orElse: () => categories.first,
+              );
+              categoryNames.add(
+                  category.name); // Add category name or "Unknown" if not found
+            }
+
+            return Right(categoryNames); // Return the list of category names
+          },
+        );
+      },
+      (categories) async {
+        // If local categories were fetched successfully
+        List<String> categoryNames = [];
+
+        for (var product in products) {
+          final category = categories.firstWhere(
+            (cat) => cat.id == product.categoryId,
+            orElse: () => categories.first,
+          );
+          categoryNames.add(category.name); // Add category name or "Unknown"
+        }
+
+        return Right(categoryNames); // Return the list of category names
+      },
+    );
   }
 }

--- a/lib/features/home/domain/repository/home_repo.dart
+++ b/lib/features/home/domain/repository/home_repo.dart
@@ -8,5 +8,6 @@ abstract class HomeRepo {
 
   Future<Either<String, List<Category>>> getCategories();
   Future<Either<String, List<Product>>> getProducts({required int page});
-
+  Future<Either<String, List<String>>> getCategoryNamesForProducts(
+      List<Product> products);
 }

--- a/lib/features/home/domain/usecases/get_category_name_for_product_usecase.dart
+++ b/lib/features/home/domain/usecases/get_category_name_for_product_usecase.dart
@@ -1,0 +1,20 @@
+import 'package:dartz/dartz.dart';
+import 'package:selaty/core/depandancy_injection/service_locator.dart';
+import 'package:selaty/core/usecase/usecase.dart';
+import 'package:selaty/features/home/domain/repository/home_repo.dart';
+import 'package:selaty/features/home/data/models/product_reesponse_model.dart'; // Import your Product model
+
+class GetCategoryNamesForProductsUsecase extends UseCase<
+    Either<String, List<String>>, GetCategoryNamesForProductsParams> {
+  @override
+  Future<Either<String, List<String>>> call(
+      {GetCategoryNamesForProductsParams? param}) async {
+    return await sl<HomeRepo>().getCategoryNamesForProducts(param!.products);
+  }
+}
+
+class GetCategoryNamesForProductsParams {
+  final List<Product> products;
+
+  GetCategoryNamesForProductsParams({required this.products});
+}

--- a/lib/features/home/presentation/logic/category_name_for_product_cubit.dart
+++ b/lib/features/home/presentation/logic/category_name_for_product_cubit.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:selaty/core/depandancy_injection/service_locator.dart';
+import 'package:selaty/core/enums/status.dart';
+import 'package:selaty/features/home/data/models/product_reesponse_model.dart';
+import 'package:selaty/features/home/domain/usecases/get_category_name_for_product_usecase.dart';
+import 'package:selaty/features/home/presentation/logic/category_name_for_product_state.dart';
+
+class CategoryNameCubit extends Cubit<CategoryNameState> {
+  CategoryNameCubit()
+      : super(CategoryNameState(
+            status: CategoryNameStatus.initial, categoryNames: []));
+
+  Future<void> fetchCategoryNames(List<Product> products) async {
+    emit(state.copyWith(status: CategoryNameStatus.loading));
+
+    final result = await sl<GetCategoryNamesForProductsUsecase>().call(
+      param: GetCategoryNamesForProductsParams(products: products),
+    );
+
+    result.fold(
+      (error) {
+        emit(state.copyWith(status: CategoryNameStatus.failure));
+      },
+      (categoryNames) {
+        emit(state.copyWith(
+            status: CategoryNameStatus.success, categoryNames: categoryNames));
+      },
+    );
+  }
+}

--- a/lib/features/home/presentation/logic/category_name_for_product_state.dart
+++ b/lib/features/home/presentation/logic/category_name_for_product_state.dart
@@ -1,0 +1,18 @@
+import 'package:selaty/core/enums/status.dart';
+
+class CategoryNameState {
+  final CategoryNameStatus status;
+  final List<String> categoryNames;
+
+  CategoryNameState({required this.status, required this.categoryNames});
+
+  CategoryNameState copyWith({
+    CategoryNameStatus? status,
+    List<String>? categoryNames,
+  }) {
+    return CategoryNameState(
+      status: status ?? this.status,
+      categoryNames: categoryNames ?? this.categoryNames,
+    );
+  }
+}

--- a/lib/features/home/presentation/views/home_view.dart
+++ b/lib/features/home/presentation/views/home_view.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart'; // Import ScreenUtil
+import 'package:selaty/core/depandancy_injection/service_locator.dart';
+import 'package:selaty/features/home/presentation/logic/category_name_for_product_cubit.dart';
 import 'package:selaty/features/home/presentation/widgets/ad_widget.dart';
 import 'package:selaty/features/home/presentation/widgets/ads_image_slider.dart';
 import 'package:selaty/features/home/presentation/widgets/best_seller_products_grid_view.dart';
@@ -58,8 +61,11 @@ class HomeView extends StatelessWidget {
                 height: 8.h, // Use ScreenUtil for spacing
               ),
             ),
-            const SliverToBoxAdapter(
-              child: BestSellerProductsGridView(),
+            SliverToBoxAdapter(
+              child: BlocProvider(
+                create: (context) => sl<CategoryNameCubit>(),
+                child: const BestSellerProductsGridView(),
+              ),
             ),
             SliverToBoxAdapter(
               child: SizedBox(

--- a/lib/features/home/presentation/views/main_view.dart
+++ b/lib/features/home/presentation/views/main_view.dart
@@ -103,20 +103,23 @@ class _MainViewState extends State<MainView> {
 
   @override
   Widget build(BuildContext context) {
-    return PersistentTabView(
-      context,
-      controller: _controller,
-      screens: _buildScreens(),
-      items: _navBarsItems(),
-      backgroundColor: Colors.white,
-      handleAndroidBackButtonPress: true,
-      resizeToAvoidBottomInset: true,
-      stateManagement: true,
-      decoration: NavBarDecoration(
-        borderRadius: BorderRadius.circular(10.0),
-        colorBehindNavBar: Colors.white,
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical:  8.0),
+      child: PersistentTabView(
+        context,
+        controller: _controller,
+        screens: _buildScreens(),
+        items: _navBarsItems(),
+        backgroundColor: Colors.white,
+        handleAndroidBackButtonPress: true,
+        resizeToAvoidBottomInset: true,
+        stateManagement: true,
+        decoration: NavBarDecoration(
+          borderRadius: BorderRadius.circular(10.0),
+          colorBehindNavBar: Colors.white,
+        ),
+        navBarStyle: NavBarStyle.style15,
       ),
-      navBarStyle: NavBarStyle.style15,
     );
   }
 }

--- a/lib/features/home/presentation/views/profile_view.dart
+++ b/lib/features/home/presentation/views/profile_view.dart
@@ -6,6 +6,7 @@ import 'package:selaty/core/constants/colors.dart';
 import 'package:selaty/core/depandancy_injection/service_locator.dart';
 import 'package:selaty/features/auth/presentation/logic/logout/logout_cubit.dart';
 import 'package:selaty/features/home/presentation/logic/categories_cubit.dart';
+import 'package:selaty/features/home/presentation/logic/category_name_for_product_cubit.dart';
 import 'package:selaty/features/home/presentation/logic/product_cubit.dart';
 import 'package:selaty/features/home/presentation/logic/slider_images_cubit.dart';
 import 'package:selaty/features/home/presentation/views/home_view.dart';
@@ -44,6 +45,7 @@ class ProfileView extends StatelessWidget {
                   BlocProvider(
                     create: (context) => sl<ProductCubit>()..fetchProducts(1),
                   ),
+                
                 ],
                 child: const HomeView(),
               ),

--- a/lib/features/home/presentation/widgets/best_seller_products_grid_view.dart
+++ b/lib/features/home/presentation/widgets/best_seller_products_grid_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:selaty/core/enums/status.dart';
+import 'package:selaty/features/home/presentation/logic/category_name_for_product_cubit.dart';
 import 'package:selaty/features/home/presentation/logic/product_cubit.dart';
 import 'package:selaty/features/home/presentation/logic/product_state.dart';
 import 'package:selaty/features/home/presentation/widgets/best_sellerproduct_card.dart';
@@ -34,6 +35,13 @@ class BestSellerProductsGridView extends StatelessWidget {
           );
         } else if (state.status == ProductStatus.success &&
             state.products != null) {
+          context.read<CategoryNameCubit>().fetchCategoryNames(state.products!);
+
+          List<String> categoryNames = [];
+          if (state.status == CategoryNameStatus.success) {
+            categoryNames =
+                context.read<CategoryNameCubit>().state.categoryNames;
+          }
           // Display products once loaded
           return Padding(
             padding: const EdgeInsets.only(right: 10),
@@ -50,7 +58,10 @@ class BestSellerProductsGridView extends StatelessWidget {
                     crossAxisSpacing: 10),
                 itemBuilder: (context, index) {
                   final product = state.products![index + 1];
-                  return BestSellerProductCard(product: product);
+                  return BestSellerProductCard(
+                    product: product,
+                    categoryNames: categoryNames,
+                  );
                 },
               ),
             ),

--- a/lib/features/home/presentation/widgets/best_sellerproduct_card.dart
+++ b/lib/features/home/presentation/widgets/best_sellerproduct_card.dart
@@ -9,8 +9,9 @@ import 'package:shimmer/shimmer.dart';
 
 class BestSellerProductCard extends StatelessWidget {
   final Product product;
-
-  const BestSellerProductCard({super.key, required this.product});
+  final List<String> categoryNames;
+  const BestSellerProductCard(
+      {super.key, required this.product, required this.categoryNames});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
### Overview
This pull request introduces the functionality to fetch category names associated with a list of products using the new `GetCategoryNamesForProductsUsecase` and manages the state through the `CategoryNameCubit`.

### Changes
- **GetCategoryNamesForProductsUsecase**: A use case that retrieves category names based on the provided products.
- **CategoryNameCubit**: Implements business logic for fetching category names and managing the loading state, success state, and failure state.
- **CategoryNameState**: A state class to hold the current status and list of category names.

### Benefits
- Improved separation of concerns by using the use case and cubit pattern.
- Enhanced maintainability and testability of the codebase.

### How to Test
- Use the `fetchCategoryNames` method in `CategoryNameCubit` to initiate fetching category names and observe the emitted states.

Please review the implementation and provide any feedback. Thank you!
